### PR TITLE
Unlink the file for Tempfile.open with a block

### DIFF
--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -290,7 +290,7 @@ class Tempfile < DelegateClass(File)
         begin
           yield(tempfile)
         ensure
-          tempfile.close
+          tempfile.close!
         end
       else
         tempfile


### PR DESCRIPTION
* Fixes https://github.com/ruby/tempfile/issues/2