### PR TITLE
Fix inconsistency in doc of Tempfile.create

### DIFF
--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -57,7 +57,7 @@ require 'tmpdir'
 # Note that Tempfile.create returns a File instance instead of a Tempfile, which
 # also avoids the overhead and complications of delegation.
 #
-#   Tempfile.open('foo') do |file|
+#   Tempfile.create('foo') do |file|
 #      # ...do something with file...
 #   end
 #


### PR DESCRIPTION
Just a tiny glitch in the documentation of `Tempfile.create`. Kinda important though since `Tempfile.open` is not intended to be used unless you know why you're doing it.