### PR TITLE
Alias Tempfile#to_s to Tempfile#inspect

### DIFF
--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -264,6 +264,7 @@ class Tempfile < DelegateClass(File)
       "#<#{self.class}:#{path}>"
     end
   end
+  alias to_s inspect
 
   class Remover # :nodoc:
     def initialize(tmpfile)


### PR DESCRIPTION
This PR implements `#to_s` as an alias for `#inspect`. Previously, `#to_s` was printing `File` which is a bit misleading.

Before:
```ruby
t = Tempfile.new
t.to_s #=> #<File:0x0000000108d0c498>
```

After:
```ruby
t = Tempfile.new
t.to_s #=> #<Tempfile:/var/folders/rh/2d2lzkfn22sfmx5227bww_km0000gn/T/20230501-30515-b2tr67>
```
