### PR TITLE
Add 'perm' keyword argument.

### DIFF
--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -283,6 +283,16 @@ puts Tempfile.new('foo').path
     end
   end
 
+  def test_new_with_no_permissions
+    t = tempfile("foo", perm: 0)
+    assert_equal 0, t.stat.mode & 0777
+  end
+
+  def test_new_with_default_permissions
+    t = tempfile("foo")
+    assert_equal 0600, t.stat.mode & 0777
+  end
+
   module M
   end
 
@@ -390,6 +400,18 @@ puts Tempfile.new('foo').path
         File.unlink(t.path)
       end
     end
+  end
+
+  def test_create_with_no_permissions
+    perm = nil
+    Tempfile.create("foo", perm: 0) { perm = _1.stat.mode & 0777 }
+    assert_equal 0, perm
+  end
+
+  def test_create_with_default_permissions
+    perm = nil
+    Tempfile.create("foo") { perm = _1.stat.mode & 0777 }
+    assert_equal 0600, perm
   end
 
   def assert_mktmpdir_traversal


### PR DESCRIPTION
Allow a temporary file to be created with no read, write or execute
permissions for any user or group. You could also choose another 
set of permissions. Similar to File.new and File.open. Continue with
the default of 0600.

Example:
```ruby
tmpfile = Tempfile.new("foo", perm: 0)
tmpfile.write("bar") # => 3
tmpfile.rewind
tmpfile.read # => bar
tmpfile.stat.mode & 0777 # => 0
```

I don't know if this will be accepted or not; if there is interest in it I can
update the docs. Thanks.