### PR TITLE
CI: macos-13 for Ruby 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,14 @@ jobs:
     needs: ruby-versions
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        exclude:
+          - { os: macos-latest, ruby: '2.5' }
+        include:
+          - { os: macos-13, ruby: '2.5' }
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This uses now-compatible "os" choices for Ruby ~2.4~, 2.5.

This failed in the build of #31.

I enabled fail-fast: false to be able to iterate on the CI workflow.


<details>
Found this:

```
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    tempfile was resolved to 0.2.1, which depends on
      Ruby (>= 2.5.0)

  Current Ruby version:
    Ruby (= 2.4.10)

```

EDIT: Noted that I had wrongly added 2.4 I am removing the 2.4 from the workflow.
</details>

Also: There are errors about a Tempfile lacking a filename in the failed tests. (These are for Ruby versions 3.1 and below.)