### PR TITLE
Define Closer finalizer on dup and clone

### DIFF
--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -242,18 +242,20 @@ class Tempfile < DelegateClass(File)
   def initialize_dup(other) # :nodoc:
     initialize_copy_iv(other)
     super(other)
+    ObjectSpace.define_finalizer(@finalizer_obj, Closer.new(__getobj__))
   end
 
   def initialize_clone(other) # :nodoc:
     initialize_copy_iv(other)
     super(other)
+    ObjectSpace.define_finalizer(@finalizer_obj, Closer.new(__getobj__))
   end
 
   private def initialize_copy_iv(other) # :nodoc:
     @unlinked = other.unlinked
     @mode = other.mode
     @opts = other.opts
-    @finalizer_obj = other.finalizer_obj
+    @finalizer_obj = Object.new
   end
 
   # Opens or reopens the file with mode "r+".


### PR DESCRIPTION
As @jeremyevans pointed out:

> Each Tempfile instance has a separate File instance and file descriptor:
>
>   t = Tempfile.new
>   t.to_i # => 6
>   t.dup.to_i => 7

This commit adds the Closer finalizer on dup and clone so that the File object is closed on GC.