### PR TITLE
Add link to RDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ file.close
 file.unlink    # deletes the temp file
 ```
 
+## Documentation
+
+[RDoc](https://docs.ruby-lang.org/en/master/Tempfile.html)
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.


### PR DESCRIPTION
Every README should link to the official RDoc if possible.