### PR TITLE
Stop using `IO::NULL` for feature detection

### DIFF
--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -593,9 +593,7 @@ private def create_with_filename(basename="", tmpdir=nil, mode: 0, **options)
   end
 end
 
-File.open(IO::NULL) do |f|
-  File.new(f.fileno, autoclose: false, path: "").path
-rescue IOError
+if RUBY_VERSION < "3.2"
   module PathAttr               # :nodoc:
     attr_reader :path
 


### PR DESCRIPTION
`IO::NULL`'s underlying file `/dev/null` is not always available on WASI, so use of the file on top-level code (introduced in https://github.com/ruby/tempfile/pull/36) causes tempfile library not to work at all on WASI.

Reported by https://github.com/ruby/ruby.wasm/issues/556